### PR TITLE
Added support for specifying screenshot views

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ buildscript {
         maven { url 'http://dl.bintray.com/shopify/shopify-android/' }
     }
     dependencies {
-        classpath 'com.shopify.testify:plugin:0.5.2'
+        classpath 'com.shopify.testify:plugin:0.5.4'
     }
 }
 apply plugin: 'com.shopify.testify'
@@ -177,6 +177,6 @@ Run `adb root` if necessary.
 
 We welcome contributions. Follow the steps in the [CONTRIBUTING](CONTRIBUTING.md) file.
 
-### License 
+### License
 
 The Mobile Buy SDK is provided under an MIT Licence. See the [LICENSE](LICENSE) file.

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ task clean(type: Delete) {
 }
 
 ext {
-    coreVersion = '0.5.3'
+    coreVersion = '0.5.4'
 }
 
 project.ext.preDexLibs = !project.hasProperty('disablePreDex')

--- a/testify/src/main/java/com/shopify/testify/ScreenshotUtility.java
+++ b/testify/src/main/java/com/shopify/testify/ScreenshotUtility.java
@@ -147,13 +147,13 @@ class ScreenshotUtility {
      * Capture a bitmap from the given Activity and save it to the screenshots directory.
      */
     @Nullable
-    Bitmap createBitmapFromActivity(final Activity activity, String testName) throws Exception {
+    Bitmap createBitmapFromActivity(final Activity activity, String testName, @Nullable final View screenshotView) throws Exception {
         final Bitmap[] currentActivityBitmap = new Bitmap[1];
         final CountDownLatch latch = new CountDownLatch(1);
         activity.runOnUiThread(new Runnable() {
             @Override
             public void run() {
-                currentActivityBitmap[0] = createBitmapFromView(activity, null);
+                currentActivityBitmap[0] = createBitmapFromView(activity, screenshotView);
                 latch.countDown();
             }
         });


### PR DESCRIPTION
**What**
* Added a method `setScreenshotViewProvider` to `BaseScreenshotTest` that lets you specify the view that should be used for capturing screenshots
* Useful when you have multiple windows active at the same time (e.g. popup menus)

