### PR TITLE
Remove hidePasswords from ScreenshotTestTask

### DIFF
--- a/plugin/src/main/groovy/com/shopify/testify/task/testify/ScreenshotTestTask.groovy
+++ b/plugin/src/main/groovy/com/shopify/testify/task/testify/ScreenshotTestTask.groovy
@@ -108,7 +108,6 @@ class ScreenshotTestTask extends TestifyDefaultTask {
     def addDependencies(Project project) {
         def tasks = project.tasks
 
-        this.dependsOn "hidePasswords"
         this.dependsOn "disableSoftKeyboard"
         this.dependsOn "showLocale"
         this.dependsOn "showTimeZone"


### PR DESCRIPTION
As discussed before, the Firebase emulator on CI does not allow changes to system settings therefore will show passwords (dotted with the last character visible) in an EditText. 

We should consider removing this step from Testify to make local screenshots more closely match Firebase.

<img width="849" alt="screen shot 2017-07-25 at 10 55 53 am" src="https://user-images.githubusercontent.com/2933650/28578487-e7a7ceac-7127-11e7-8cef-96a54fafa8fc.png">
