### PR TITLE
Remove ktlint html formatter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@ buildscript {
                 'dokka'                   : '0.9.18',         // https://github.com/Kotlin/dokka/releases
                 'kotlin'                  : '1.3.21',         // https://kotlinlang.org/
                 'ktlint'                  : '0.29.0',         // https://github.com/shyiko/ktlint
-                'ktlintHtml'              : '0.2.0',          // https://github.com/mcassiano/ktlint-html-reporter
                 'maven'                   : '2.1',            // https://github.com/dcendents/android-maven-gradle-plugin/releases
                 'mockito2'                : '2.23.0',         // https://github.com/mockito/mockito/releases
                 'mockitokotlin'           : '2.1.0',          // https://github.com/nhaarman/mockito-kotlin
@@ -53,7 +52,6 @@ buildscript {
                         'lint'        : [
                                 'main': "com.github.shyiko:ktlint:${versions.ktlint}",
                         ],
-                        'lintHtml'    : "me.cassiano:ktlint-html-reporter:${versions.ktlintHtml}",
                         'stdlib7'     : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}",
                 ],
                 'mockito' : [

--- a/ktlint.gradle
+++ b/ktlint.gradle
@@ -17,6 +17,6 @@ task ktlint(type: JavaExec, group: "verification") {
     description = "Check Kotlin code style."
     classpath = configurations.ktlint
     main = "com.github.shyiko.ktlint.Main"
-    args "src/**/*.kt", "--reporter=plain", "--reporter=checkstyle,output=${buildDir}/reports/ktlint/ktlint.xml", "--reporter=html,artifact=${depends.kotlin.lintHtml},output=${buildDir}/reports/ktlint/ktlint.html"
+    args "src/**/*.kt", "--reporter=plain", "--reporter=checkstyle,output=${buildDir}/reports/ktlint/ktlint.xml"
 }
 check.dependsOn ktlint


### PR DESCRIPTION
ktlint-html-reporter has been deprecated and will no longer be maintained as the reporter is now available through ktlint