### PR TITLE
Update Testify to 1.0.0-beta2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Testify Change Log
 
-## 1.0.1-beta1 -- May 5, 2020
+## 1.0.0-beta2 -- May 20, 2020
 
 ### Library
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "com.shopify.testify:plugin:1.0.0-beta1"
+        classpath "com.shopify.testify:plugin:1.0.0-beta2"
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ buildscript {
                 'mockito2'                : '2.28.2',         // https://github.com/mockito/mockito/releases
                 'mockitoAndroid'          : '3.3.3',          // https://mvnrepository.com/artifact/org.mockito/mockito-android
                 'mockitokotlin'           : '2.1.0',          // https://github.com/nhaarman/mockito-kotlin
-                'testify'                 : '1.0.0-beta1',    // https://github.com/Shopify/android-testify/releases
+                'testify'                 : '1.0.0-beta2',    // https://github.com/Shopify/android-testify/releases
         ]
         coreVersions = [
                 'shopify': [


### PR DESCRIPTION
### What does this change accomplish?

This PR updates Testify from `1.0.0-beta1` to `1.0.0-beta2` so that we can release the newest bug fixes.

### How have you achieved it?

1 - Updated the version
2 - Updated the `README`
3 - Updated the `CHANGELOG` to have the more relevant version number and date (since `1.0.1-beta1` did not exist). Unsure if I should I should backfill entries for the other bugfixes since `1.0.0-beta1` or if they were left out intentionally. @DanielJette 

