### PR TITLE
Make orientation changes more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,14 @@
 
 ### Library
 
-#### Changes
+#### Bug fixes
 
-- Replace the existing FuzzyCompare algorithm with CIEDE2000. Calculate the colour difference value between two colours in lab space.
+- Fix https://github.com/Shopify/android-testify/issues/165
+    Increase the timeout on the ActivityLifecycleMonitor to 5 seconds to allow for the rotation to complete.
+    Deregister the lifecycle callback.
+
+- Fix https://github.com/Shopify/android-testify/issues/166
+    Replace the existing FuzzyCompare algorithm with CIEDE2000. Calculate the colour difference value between two colours in lab space.
     The CIELAB color space (also known as CIE L* a* b* or sometimes abbreviated as simply "Lab" color space) is a color space defined by the International Commission on Illumination (CIE) in 1976.
     It expresses color as three values: L* for the lightness from black (0) to white (100), a* from green (−) to red (+), and b* from blue (−) to yellow (+).
     CIELAB was designed so that the same amount of numerical change in these values corresponds to roughly the same amount of visually perceived change.

--- a/Library/src/main/java/com/shopify/testify/internal/helpers/OrientationHelper.kt
+++ b/Library/src/main/java/com/shopify/testify/internal/helpers/OrientationHelper.kt
@@ -114,9 +114,13 @@ internal class OrientationHelper<T : Activity>(
             throw UnexpectedOrientationException("Failed to apply requested rotation.")
         }
 
-        // Wait for the activity to fully resume
-        if (!lifecycleLatch.await(1, TimeUnit.SECONDS)) {
-            throw UnexpectedOrientationException("Activity did not resume.")
+        try {
+            // Wait for the activity to fully resume
+            if (!lifecycleLatch.await(5, TimeUnit.SECONDS)) {
+                throw UnexpectedOrientationException("Activity did not resume.")
+            }
+        } finally {
+            ActivityLifecycleMonitorRegistry.getInstance().removeLifecycleCallback(::lifecycleCallback)
         }
     }
 }

--- a/Library/src/test/java/com/shopify/testify/FuzzyCompareTest.kt
+++ b/Library/src/test/java/com/shopify/testify/FuzzyCompareTest.kt
@@ -133,8 +133,8 @@ class FuzzyCompareTest {
 
     @Test
     fun largeArea() {
-        repeat((0..1024).count()) {
-            repeat((0..768).count()) {
+        repeat(1024) {
+            repeat(768) {
                 val color1 = RGB(Random.nextInt(5, 250), Random.nextInt(5, 250), Random.nextInt(5, 250))
                 val color2 = RGB(color1.r + Random.nextInt(-5, 5), color1.g + Random.nextInt(-5, 5), color1.b + Random.nextInt(-5, 5))
                 val deltaE = calculateDeltaE(color1.toLAB(), color2.toLAB())


### PR DESCRIPTION
### What does this change accomplish?

Resolves https://github.com/Shopify/android-testify/issues/165

### How have you achieved it?

I noticed that, when failing, it was usually due to `Activity did not resume` errors. I also observed that orientation change tests regularly take between 1.5 and 3 seconds. I speculate that the latch was tripping prematurely and we needed a little more time to confirm the orientation change.

- Increase the timeout on the ActivityLifecycleMonitor to 5 seconds to allow for the rotation to complete.
- Deregister the lifecycle callback.

### Tophat instructions

- Run `OrientationTest` frequently.

### Notice

This change must keep `master` in a shippable state; **it may be shipped without further notice**.

<!--
Need help in filling this out? See the [guide](https://github.com/Shopify/android-testify/blob/master/CONTRIBUTING.md).
-->
