### PR TITLE
Properly support Android Studio 4.1

### DIFF
--- a/Plugins/IntelliJ/CHANGELOG.md
+++ b/Plugins/IntelliJ/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+## [0.0.2]
+
+### Fixed
+
+- Fixed an issue preventing the Testify gradle commands from working in Android Studio 4.1.
+
+### Changed
+
+- Upgraded Kotlin JVM from 1.3.72 to 1.4.10.
+- Upgraded Intellij Changelog Plugin from 0.3.3 to 0.6.2.
+- Upgraded ktlinter from 9.2.1 to 9.4.1.
+- Pin kotlin-reflect to version 1.4.10
+- Upgrade Intellij platform version to 2020.1
+- Corrected assorted lint formatting errors.
+
 ## [0.0.1]
 
 ### Added

--- a/Plugins/IntelliJ/build.gradle.kts
+++ b/Plugins/IntelliJ/build.gradle.kts
@@ -4,13 +4,13 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     // Kotlin support
-    id("org.jetbrains.kotlin.jvm") version "1.3.72"
+    id("org.jetbrains.kotlin.jvm") version "1.4.10"
     // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
     id("org.jetbrains.intellij") version "0.4.21"
     // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
-    id("org.jetbrains.changelog") version "0.3.3"
+    id("org.jetbrains.changelog") version "0.6.2"
     // ktlint linter - read more: https://github.com/JLLeitschuh/ktlint-gradle
-    id("org.jlleitschuh.gradle.ktlint") version "9.2.1"
+    id("org.jlleitschuh.gradle.ktlint") version "9.4.1"
 }
 
 // Import variables from gradle.properties file
@@ -35,6 +35,7 @@ repositories {
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
     implementation(kotlin("script-runtime"))
+    implementation("org.jetbrains.kotlin:kotlin-reflect:1.4.10")
 }
 
 // Configure gradle-intellij-plugin plugin.
@@ -71,16 +72,20 @@ tasks {
         untilBuild(pluginUntilBuild)
 
         // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
-        pluginDescription(closure {
-            File("${project.rootDir.path}/README.md").readText().lines().run {
-                subList(indexOf("<!-- Plugin description -->") + 1, indexOf("<!-- Plugin description end -->"))
-            }.joinToString("\n").run { markdownToHTML(this) }
-        })
+        pluginDescription(
+            closure {
+                File("${project.rootDir.path}/README.md").readText().lines().run {
+                    subList(indexOf("<!-- Plugin description -->") + 1, indexOf("<!-- Plugin description end -->"))
+                }.joinToString("\n").run { markdownToHTML(this) }
+            }
+        )
 
         // Get the latest available change notes from the changelog file
-        changeNotes(closure {
-            changelog.getLatest().toHTML()
-        })
+        changeNotes(
+            closure {
+                changelog.getLatest().toHTML()
+            }
+        )
     }
 
     publishPlugin {

--- a/Plugins/IntelliJ/gradle.properties
+++ b/Plugins/IntelliJ/gradle.properties
@@ -3,10 +3,10 @@
 
 pluginGroup = com.shopify.testify
 pluginName = Android Testify - Screenshot Instrumentation Tests
-pluginVersion = 0.0.1
+pluginVersion = 0.0.2
 pluginSinceBuild = 193
 pluginUntilBuild = 201.*
 
 platformType = IC
-platformVersion = 2019.3
+platformVersion = 2020.1
 platformDownloadSources = true

--- a/Plugins/IntelliJ/src/main/kotlin/com/shopify/testify/PsiExtensions.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/com/shopify/testify/PsiExtensions.kt
@@ -33,7 +33,10 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 val AnActionEvent.moduleName: String
     get() {
         val psiFile = this.getData(PlatformDataKeys.PSI_FILE)
-        return (psiFile as? KtFile)?.module?.name ?: ""
+        val ktFile = (psiFile as? KtFile)
+        val projectName = ktFile?.project?.name?.replace(' ', '_') ?: ""
+        val moduleName = ktFile?.module?.name ?: ""
+        return moduleName.removePrefix("$projectName.")
     }
 
 val PsiElement.baselineImageName: String

--- a/Plugins/IntelliJ/src/main/kotlin/com/shopify/testify/extensions/RecordMarkerProvider.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/com/shopify/testify/extensions/RecordMarkerProvider.kt
@@ -63,7 +63,8 @@ class RecordMarkerProvider : LineMarkerProvider {
             ICON,
             TooltipProvider { "Android Testify Commands" },
             NavHandler(element),
-            GutterIconRenderer.Alignment.RIGHT)
+            GutterIconRenderer.Alignment.RIGHT
+        )
     }
 
     companion object {


### PR DESCRIPTION
### What does this change accomplish?

Resolves https://github.com/Shopify/android-testify/issues/176

### How have you achieved it?

The `module.name` method on `KtFile` used to output just the simple module name (e.g. `Sample`) but in AS 4.1, this method now reports the fully qualified module name (e.g. `android-testify.Sample`). Unfortunately, this naming convention is not supported by Gradle (up to 6.5 at least) and so the plugin integrations fail. 

This change is primarily to parse the Module Name so that it's compatible with Gradle commands. While here, I also updated a few version dependencies (and fixed some lint errors).

### Tophat instructions

To test these changes locally:



1. :warning: Please ensure you uninstall any existing versions of Android Testify before testing this PR
1. Download a local copy of the plugin: [Testify IntelliJ Plugin-0.0.2.zip](https://github.com/Shopify/android-testify/files/5440527/Testify.IntelliJ.Plugin-0.0.2.zip)
1. Install the local copy
From Android Studio `Preferences`:
<img width="200px" src="https://user-images.githubusercontent.com/5921367/97204359-61e21980-178c-11eb-88f0-2e77224ce3f6.png"/>
<img width="600px" src="https://user-images.githubusercontent.com/5921367/97204500-89d17d00-178c-11eb-82a8-f1c45a6df749.png"/>
<img width="200px" src="https://user-images.githubusercontent.com/5921367/97204638-b5546780-178c-11eb-8d5c-107ce1b01556.png"/>

### Notice

This change must keep `master` in a shippable state; **it may be shipped without further notice**.

<!--
Need help in filling this out? See the [guide](https://github.com/Shopify/android-testify/blob/master/CONTRIBUTING.md).
-->
