### PR TITLE
Generously increase the timeout values for the orientation change latches

### DIFF
--- a/Library/src/main/java/com/shopify/testify/internal/helpers/OrientationHelper.kt
+++ b/Library/src/main/java/com/shopify/testify/internal/helpers/OrientationHelper.kt
@@ -110,13 +110,13 @@ internal class OrientationHelper<T : Activity>(
         }
 
         // Wait for the rotation request to be made
-        if (!rotationLatch.await(1, TimeUnit.SECONDS)) {
+        if (!rotationLatch.await(30, TimeUnit.SECONDS)) {
             throw UnexpectedOrientationException("Failed to apply requested rotation.")
         }
 
         try {
             // Wait for the activity to fully resume
-            if (!lifecycleLatch.await(5, TimeUnit.SECONDS)) {
+            if (!lifecycleLatch.await(30, TimeUnit.SECONDS)) {
                 throw UnexpectedOrientationException("Activity did not resume.")
             }
         } finally {


### PR DESCRIPTION
### What does this change accomplish?

`OrientationHelper` uses two latches to synchronize the orientation changes. The first is to sync the UI thread and test thread. It normally completes in only a few milliseconds, so its timeout was only 1 second. The second latch waits for the orientation change to complete. This can take longer, so it had a 5 second latch. However, on CI (specifically the GitHub Actions), these latches would fail pretty much 100% of the time.
I could never get these to fail locally, so I just bumped the timeouts on each to 30s and we'll see if that makes a difference.


### Tophat instructions

All the tests in `Sample` should pass both locally and on CI.
In particular, all the tests in `class OrientationTest`.


### Notice

This change must keep `master` in a shippable state; **it may be shipped without further notice**.

<!--
Need help in filling this out? See the [guide](https://github.com/Shopify/android-testify/blob/master/CONTRIBUTING.md).
-->
