### PR TITLE
rootViewId on ScreenshotRule is now public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,17 @@
 # Testify Change Log
 
-
 ## Unreleased
 
 ### Library
 
 #### Changes
 
+- ScreenshotUtility is now public
 - ScreenshotBaselineNotDefinedException now reports the expected device key
+
+#### Added
+
+- Public method getRootViewId() has been added to ScreenshotRule
 
 ## 1.0.0-rc2
 

--- a/Library/src/main/java/com/shopify/testify/ScreenshotRule.kt
+++ b/Library/src/main/java/com/shopify/testify/ScreenshotRule.kt
@@ -197,7 +197,7 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
     }
 
     @IdRes
-    fun getRootViewId() : Int {
+    fun getRootViewId(): Int {
         return rootViewId
     }
 

--- a/Library/src/main/java/com/shopify/testify/ScreenshotRule.kt
+++ b/Library/src/main/java/com/shopify/testify/ScreenshotRule.kt
@@ -196,6 +196,11 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
         return this
     }
 
+    @IdRes
+    fun getRootViewId() : Int {
+        return rootViewId
+    }
+
     fun setRootViewId(@IdRes rootViewId: Int): ScreenshotRule<T> {
         this.rootViewId = rootViewId
         return this

--- a/Library/src/main/java/com/shopify/testify/ScreenshotUtility.kt
+++ b/Library/src/main/java/com/shopify/testify/ScreenshotUtility.kt
@@ -47,7 +47,7 @@ import java.io.InputStream
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
-internal class ScreenshotUtility {
+class ScreenshotUtility {
 
     private val preferredBitmapOptions: BitmapFactory.Options
         get() {


### PR DESCRIPTION
### What does this change accomplish?

Resolves #186 

### How have you achieved it?

rootViewId on ScreenshotRule is now public
ScreenshotUtility is now public. (t was always meant to be public. I think it was accidentally made internal during the conversion to Kotlin.

### Tophat instructions

n/a

### Notice

This change must keep `master` in a shippable state; **it may be shipped without further notice**.

<!--
Need help in filling this out? See the [guide](https://github.com/Shopify/android-testify/blob/master/CONTRIBUTING.md).
-->
