### PR TITLE
ScreenshotBaselineNotDefinedException now reports the expected device key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Testify Change Log
 
+
+## Unreleased
+
+### Library
+
+#### Changes
+
+- ScreenshotBaselineNotDefinedException now reports the expected device key
+
 ## 1.0.0-rc2
 
 ### Library

--- a/Library/src/main/java/com/shopify/testify/ScreenshotRule.kt
+++ b/Library/src/main/java/com/shopify/testify/ScreenshotRule.kt
@@ -438,7 +438,12 @@ open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
                         instrumentationPrintln("\n\t✓ " + 27.toChar() + "[36mRecording baseline for " + testName + 27.toChar() + "[0m")
                         return
                     } else {
-                        throw ScreenshotBaselineNotDefinedException(getModuleName(), testName, fullyQualifiedTestPath)
+                        throw ScreenshotBaselineNotDefinedException(
+                                moduleName = getModuleName(),
+                                testName = testName,
+                                testClass = fullyQualifiedTestPath,
+                                deviceKey = DeviceIdentifier.formatDeviceString(DeviceIdentifier.DeviceStringFormatter(testContext, null), DeviceIdentifier.DEFAULT_FOLDER_FORMAT)
+                        )
                     }
 
                 val bitmapCompare: BitmapCompare = when {

--- a/Library/src/main/java/com/shopify/testify/internal/exception/ScreenshotBaselineNotDefinedException.kt
+++ b/Library/src/main/java/com/shopify/testify/internal/exception/ScreenshotBaselineNotDefinedException.kt
@@ -24,5 +24,17 @@
 
 package com.shopify.testify.internal.exception
 
-class ScreenshotBaselineNotDefinedException(moduleName: String, testName: String, testClass: String) :
-        Exception("\n\n*  A baseline screenshot could not be found for '$testName'.\n*  To record a baseline screenshot, run `./gradlew $moduleName:screenshotRecord -PtestClass=$testClass`\n")
+class ScreenshotBaselineNotDefinedException(
+    moduleName: String,
+    testName: String,
+    testClass: String,
+    deviceKey: String
+) :
+        Exception(
+"""
+
+*  A baseline screenshot could not be found for '$testName'.
+*  Baseline could not be found in $deviceKey.
+*  To record a baseline screenshot, run `./gradlew $moduleName:screenshotRecord -PtestClass=$testClass`
+"""
+        )


### PR DESCRIPTION
### What does this change accomplish?

Add the device key to ScreenshotBaselineNotDefinedException

Resolves #188 

### How have you achieved it?

Add the line `Baseline could not be found in $deviceKey` to  ScreenshotBaselineNotDefinedException

e.g:
```
    com.shopify.testify.internal.exception.ScreenshotBaselineNotDefinedException:

    *  A baseline screenshot could not be found for 'ScreenshotRuleExampleTests_default'.
    *  Baseline could not be found in 30-1080x2220@440dp-en_US
    *  To record a baseline screenshot, run `./gradlew :screenshotRecord -PtestClass=com.shopify.testify.sample.ScreenshotRuleExampleTests#default`
```


### Tophat instructions

Delete any of the baseline images from the Sample app and run the tests. You should see the updated error message.

### Notice

This change must keep `master` in a shippable state; **it may be shipped without further notice**.

<!--
Need help in filling this out? See the [guide](https://github.com/Shopify/android-testify/blob/master/CONTRIBUTING.md).
-->
