### PR TITLE
Update intellij_build.yml

### DIFF
--- a/.github/workflows/intellij_build.yml
+++ b/.github/workflows/intellij_build.yml
@@ -15,7 +15,7 @@
 ## JBIJPPTPL
 
 name: Build IntelliJ Platform Plugin
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
 


### PR DESCRIPTION
### What does this change accomplish?

Looks like the intellij draft release needs to be created on `push`


### Notice

This change must keep `master` in a shippable state; **it may be shipped without further notice**.

<!--
Need help in filling this out? See the [guide](https://github.com/Shopify/android-testify/blob/master/CONTRIBUTING.md).
-->
