### PR TITLE
Support aliases for TestifyFeatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 #### Changes
 
+- TestifyFeatures now support multiple named strings.
+- PixelCopyCapture can be enabled using either "testify-experimental-capture" or "testify-pixelcopy-capture" in the AndroidManifest
 - FuzzyCompare (setExactness) is now multi-threaded and significantly faster.
 
 

--- a/Library/src/main/java/com/shopify/testify/TestifyFeatures.kt
+++ b/Library/src/main/java/com/shopify/testify/TestifyFeatures.kt
@@ -3,13 +3,14 @@ package com.shopify.testify
 import android.content.Context
 import android.content.pm.PackageManager
 
-enum class TestifyFeatures(internal val tag: String, private val defaultValue: Boolean = false) {
+enum class TestifyFeatures(internal val tags: List<String>, private val defaultValue: Boolean = false) {
 
-    ExampleFeature("testify-example", defaultValue = true),
-    ExampleDisabledFeature("testify-disabled"),
-    Locale("testify-experimental-locale", defaultValue = true),
-    CanvasCapture("testify-canvas-capture"),
-    PixelCopyCapture("testify-experimental-capture");
+    ExampleFeature(listOf("testify-example", "testify-alias"), defaultValue = true),
+    ExampleDisabledFeature(listOf("testify-disabled")),
+
+    Locale(listOf("testify-experimental-locale"), defaultValue = true),
+    CanvasCapture(listOf("testify-canvas-capture")),
+    PixelCopyCapture(listOf("testify-experimental-capture", "testify-pixelcopy-capture"));
 
     private var override: Boolean? = null
 
@@ -29,7 +30,11 @@ enum class TestifyFeatures(internal val tag: String, private val defaultValue: B
         get() {
             val applicationInfo = this?.packageManager?.getApplicationInfo(packageName, PackageManager.GET_META_DATA)
             val metaData = applicationInfo?.metaData
-            return if (metaData?.containsKey(tag) == true) metaData.getBoolean(tag) else null
+
+            val tag = tags.find { tag ->
+                metaData?.containsKey(tag) == true
+            }
+            return if (tag != null) metaData?.getBoolean(tag) else null
         }
 
     companion object {

--- a/Library/src/test/java/com/shopify/testify/TestifyFeaturesTest.kt
+++ b/Library/src/test/java/com/shopify/testify/TestifyFeaturesTest.kt
@@ -46,7 +46,7 @@ class TestifyFeaturesTest {
         assertFalse(ExampleFeature.isEnabled())
     }
 
-    private fun mockContext(feature: TestifyFeatures, enabled: Boolean): Context {
+    private fun mockContext(tag: String, enabled: Boolean): Context {
         val mockPackageManager: PackageManager = mock()
         val mockContext: Context = mock {
             on { packageManager } doReturn mockPackageManager
@@ -54,8 +54,8 @@ class TestifyFeaturesTest {
         }
         doReturn(mock<ApplicationInfo>().apply {
             metaData = mock {
-                on { containsKey(feature.tag) } doReturn true
-                on { getBoolean(feature.tag) } doReturn enabled
+                on { containsKey(tag) } doReturn true
+                on { getBoolean(tag) } doReturn enabled
             }
         }).whenever(mockPackageManager).getApplicationInfo("com.testify.sample", GET_META_DATA)
         return mockContext
@@ -63,18 +63,18 @@ class TestifyFeaturesTest {
 
     @Test
     fun `Can use AndroidManifest to override an enabled feature`() {
-        assertFalse(ExampleFeature.isEnabled(mockContext(ExampleFeature, enabled = false)))
+        assertFalse(ExampleFeature.isEnabled(mockContext(ExampleFeature.tags.first(), enabled = false)))
     }
 
     @Test
     fun `Can use AndroidManifest to override a disabled feature`() {
-        assertTrue(ExampleDisabledFeature.isEnabled(mockContext(ExampleDisabledFeature, enabled = true)))
+        assertTrue(ExampleDisabledFeature.isEnabled(mockContext(ExampleDisabledFeature.tags.first(), enabled = true)))
     }
 
     @Test
     fun `Can use setEnabled to override a manifest change`() {
         ExampleFeature.setEnabled(enabled = true)
-        assertTrue(ExampleFeature.isEnabled(mockContext(ExampleFeature, enabled = false)))
+        assertTrue(ExampleFeature.isEnabled(mockContext(ExampleFeature.tags.first(), enabled = false)))
     }
 
     @Test
@@ -89,5 +89,15 @@ class TestifyFeaturesTest {
         ExampleDisabledFeature.setEnabled(true)
         TestifyFeatures.reset()
         assertFalse(ExampleDisabledFeature.isEnabled())
+    }
+
+    @Test
+    fun `Can not use a random name`() {
+        assertTrue(ExampleFeature.isEnabled(mockContext("random-tag", enabled = false)))
+    }
+
+    @Test
+    fun `Can use an alias in the AndroidManifest to enable a feature`() {
+        assertFalse(ExampleFeature.isEnabled(mockContext("testify-alias", enabled = false)))
     }
 }


### PR DESCRIPTION
### What does this change accomplish?

- TestifyFeatures now support multiple named strings.
- PixelCopyCapture can be enabled using either "testify-experimental-capture" or "testify-pixelcopy-capture" in the AndroidManifest

### Tophat instructions

Try adding `<meta-data android:name="testify-pixelcopy-capture" android:value="true" />` to the Sample's AndroidManifest.xml and notice that all the tests will fail due to the differences in the captured bitmaps.

### Notice

This change must keep `master` in a shippable state; **it may be shipped without further notice**.

<!--
Need help in filling this out? See the [guide](https://github.com/Shopify/android-testify/blob/master/CONTRIBUTING.md).
-->
