### PR TITLE
Update dependency versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,26 @@
 - Added method `ScreenshotRule.afterScreenshot(activity: Activity, currentBitmap: Bitmap?)`. This method is invoked immediately after the screenshot has been taken.
 - Added method `ScreenshotRule.applyViewModifications(parentView: ViewGroup)`. This method is called on the parent view to make runtime modifications to the view properties or layout.
 
+#### Updates:
+
+- Compile and Target SDK from 29 to 30
+- AGP from 4.1.0 to 4.2.0-beta6
+- Gradle from 6.5 to 6.7.1
+- Kotlin from 1.3.72 to 1.4.31
+- AppCompat from 1.1.0 to 1.2.0
+- Espresso from 3.2.0 to 3.3.0
+- JUnit from 1.1.1 to 1.1.2
+- Test Rules from 1.2.0 to 1.3.0
+- Test Runner from 1.1.1 to 1.3.0
+
+### Sample
+
+#### Updates:
+
+- Material from 1.1.0 to 1.3.0
+- MockitoKotlin from 2.1.0 to 2.2.0
+
+
 ## 1.0.0-rc3
 
 ### Library

--- a/Library/src/androidTest/java/com/shopify/testify/ActivityNotRegisteredExceptionTest.kt
+++ b/Library/src/androidTest/java/com/shopify/testify/ActivityNotRegisteredExceptionTest.kt
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Shopify Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.shopify.testify
 
 import android.app.Activity
@@ -11,12 +34,14 @@ class InvalidActivity : Activity()
 
 class ActivityNotRegisteredExceptionTest {
 
-    @get:Rule val rule = ScreenshotRule(
-            activityClass = InvalidActivity::class.java,
-            launchActivity = false
+    @get:Rule
+    val rule = ScreenshotRule(
+        activityClass = InvalidActivity::class.java,
+        launchActivity = false
     )
 
-    @get:Rule var thrown: ExpectedException = ExpectedException.none()
+    @get:Rule
+    var thrown: ExpectedException = ExpectedException.none()
 
     @ScreenshotInstrumentation
     @Test

--- a/Library/src/androidTest/java/com/shopify/testify/BitmapCompareTest.kt
+++ b/Library/src/androidTest/java/com/shopify/testify/BitmapCompareTest.kt
@@ -21,6 +21,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+@file:Suppress("deprecation")
+
 package com.shopify.testify
 
 import android.app.Activity
@@ -40,7 +42,8 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class BitmapCompareTest {
 
-    @get:Rule var testActivityRule = ActivityTestRule(TestActivity::class.java)
+    @get:Rule
+    var testActivityRule = ActivityTestRule(TestActivity::class.java)
 
     private val screenshotUtility = ScreenshotUtility()
     private lateinit var baselineBitmap: Bitmap

--- a/Library/src/androidTest/java/com/shopify/testify/ExperimentalPixelCopyTest.kt
+++ b/Library/src/androidTest/java/com/shopify/testify/ExperimentalPixelCopyTest.kt
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Shopify Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.shopify.testify
 
 import android.os.Build

--- a/Library/src/androidTest/java/com/shopify/testify/FuzzyCompareBitmapTest.kt
+++ b/Library/src/androidTest/java/com/shopify/testify/FuzzyCompareBitmapTest.kt
@@ -1,3 +1,28 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Shopify Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+@file:Suppress("deprecation")
+
 package com.shopify.testify
 
 import android.graphics.Bitmap

--- a/Library/src/androidTest/java/com/shopify/testify/ScreenshotInstrumentationOrientationTest.kt
+++ b/Library/src/androidTest/java/com/shopify/testify/ScreenshotInstrumentationOrientationTest.kt
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Shopify Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.shopify.testify
 
 import android.content.pm.ActivityInfo

--- a/Library/src/androidTest/java/com/shopify/testify/ScreenshotUtilityTest.kt
+++ b/Library/src/androidTest/java/com/shopify/testify/ScreenshotUtilityTest.kt
@@ -21,23 +21,26 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+@file:Suppress("deprecation")
+
 package com.shopify.testify
 
 import android.view.View
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.ActivityTestRule
-import java.io.File
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.File
 
 @RunWith(AndroidJUnit4::class)
 class ScreenshotUtilityTest {
 
-    @get:Rule var testActivityRule = ActivityTestRule(TestActivity::class.java)
+    @get:Rule
+    var testActivityRule = ActivityTestRule(TestActivity::class.java)
 
     @Test
     fun loadBaselineBitmapForComparison() {

--- a/Library/src/androidTest/java/com/shopify/testify/ViewModificationExceptionTest.kt
+++ b/Library/src/androidTest/java/com/shopify/testify/ViewModificationExceptionTest.kt
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Shopify Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package com.shopify.testify
 
 import android.view.View

--- a/Library/src/main/java/com/shopify/testify/ScreenshotRule.kt
+++ b/Library/src/main/java/com/shopify/testify/ScreenshotRule.kt
@@ -21,6 +21,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+@file:Suppress("deprecation")
+
 package com.shopify.testify
 
 import android.app.Activity

--- a/Library/src/main/java/com/shopify/testify/internal/DeviceIdentifier.kt
+++ b/Library/src/main/java/com/shopify/testify/internal/DeviceIdentifier.kt
@@ -38,9 +38,11 @@ internal object DeviceIdentifier {
 
     @JvmStatic
     val DEFAULT_FOLDER_FORMAT = "a-wxh@d-l"
+
     @JvmStatic
     val DEFAULT_NAME_FORMAT = "c_n"
 
+    @Suppress("DEPRECATION")
     private fun getDeviceDimensions(context: Context): Pair<Int, Int> {
         val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
         val metrics = DisplayMetrics()

--- a/Library/src/main/java/com/shopify/testify/internal/helpers/OrientationHelper.kt
+++ b/Library/src/main/java/com/shopify/testify/internal/helpers/OrientationHelper.kt
@@ -21,6 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+@file:Suppress("deprecation")
 package com.shopify.testify.internal.helpers
 
 import android.app.Activity

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 
     ext {
         versions = [
-                'androidGradlePlugin': '4.2.0-beta06',             // https://developer.android.com/studio/releases/gradle-plugin.html
+                'androidGradlePlugin': '4.2.0-beta06',      // https://developer.android.com/studio/releases/gradle-plugin.html
                 'androidx'           : [
                         'constraintLayout': '2.0.0-beta4',  // https://developer.android.com/jetpack/androidx/releases
                         'appCompat'       : '1.2.0',        // https://developer.android.com/jetpack/androidx/releases

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
                 'androidGradlePlugin': '4.2.0-beta06',             // https://developer.android.com/studio/releases/gradle-plugin.html
                 'androidx'           : [
                         'constraintLayout': '2.0.0-beta4',  // https://developer.android.com/jetpack/androidx/releases
-                        'appCompat'       : '1.1.0',        // https://developer.android.com/jetpack/androidx/releases
+                        'appCompat'       : '1.2.0',        // https://developer.android.com/jetpack/androidx/releases
                         'coreKtx'         : '1.1.0',        // https://developer.android.com/jetpack/androidx/releases
                         'test'            : [
                                 'core'    : '2.1.0',        // https://developer.android.com/jetpack/androidx/releases
@@ -26,7 +26,7 @@ buildscript {
                 'kotlin'             : '1.4.31',            // https://kotlinlang.org/
                 'ktlint'             : '0.36.0',            // https://github.com/pinterest/ktlint
                 'maven'              : '2.1',               // https://github.com/dcendents/android-maven-gradle-plugin/releases
-                'material'           : '1.1.0',             // https://material.io/develop/android/docs/getting-started/
+                'material'           : '1.3.0',             // https://material.io/develop/android/docs/getting-started/
                 'mockito2'           : '3.3.3',             // https://github.com/mockito/mockito/releases
                 'mockitoAndroid'     : '3.3.3',             // https://mvnrepository.com/artifact/org.mockito/mockito-android
                 'mockitokotlin'      : '2.2.0',             // https://github.com/nhaarman/mockito-kotlin

--- a/build.gradle
+++ b/build.gradle
@@ -14,10 +14,10 @@ buildscript {
                         'coreKtx'         : '1.1.0',        // https://developer.android.com/jetpack/androidx/releases
                         'test'            : [
                                 'core'    : '2.1.0',        // https://developer.android.com/jetpack/androidx/releases
-                                'espresso': '3.2.0',        // https://developer.android.com/jetpack/androidx/releases
-                                'junit'   : '1.1.1',        // https://developer.android.com/jetpack/androidx/releases
-                                'rules'   : '1.2.0',        // https://developer.android.com/jetpack/androidx/releases
-                                'runner'  : '1.1.1',        // https://developer.android.com/jetpack/androidx/releases
+                                'espresso': '3.3.0',        // https://developer.android.com/jetpack/androidx/releases
+                                'junit'   : '1.1.2',        // https://developer.android.com/jetpack/androidx/releases
+                                'rules'   : '1.3.0',        // https://developer.android.com/jetpack/androidx/releases
+                                'runner'  : '1.3.0',        // https://developer.android.com/jetpack/androidx/releases
                         ]
                 ],
                 'bintray'            : '1.8.4',             // https://github.com/bintray/gradle-bintray-plugin/releases

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
                 'bintray'            : '1.8.4',             // https://github.com/bintray/gradle-bintray-plugin/releases
                 'colormath'          : '1.4.1',             // https://github.com/ajalt/colormath/releases
                 'dokka'              : '0.10.0',            // https://github.com/Kotlin/dokka/releases
-                'kotlin'             : '1.3.72',            // https://kotlinlang.org/
+                'kotlin'             : '1.4.31',            // https://kotlinlang.org/
                 'ktlint'             : '0.36.0',            // https://github.com/pinterest/ktlint
                 'maven'              : '2.1',               // https://github.com/dcendents/android-maven-gradle-plugin/releases
                 'material'           : '1.1.0',             // https://material.io/develop/android/docs/getting-started/

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ buildscript {
         coreVersions = [
                 'compileSdk': 30,
                 'minSdk'    : 19,
-                'targetSdk' : 29
+                'targetSdk' : 30
         ]
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 
     ext {
         versions = [
-                'androidGradlePlugin': '4.1.0',             // https://developer.android.com/studio/releases/gradle-plugin.html
+                'androidGradlePlugin': '4.2.0-beta06',             // https://developer.android.com/studio/releases/gradle-plugin.html
                 'androidx'           : [
                         'constraintLayout': '2.0.0-beta4',  // https://developer.android.com/jetpack/androidx/releases
                         'appCompat'       : '1.1.0',        // https://developer.android.com/jetpack/androidx/releases

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ buildscript {
                 'material'           : '1.1.0',             // https://material.io/develop/android/docs/getting-started/
                 'mockito2'           : '3.3.3',             // https://github.com/mockito/mockito/releases
                 'mockitoAndroid'     : '3.3.3',             // https://mvnrepository.com/artifact/org.mockito/mockito-android
-                'mockitokotlin'      : '2.1.0',             // https://github.com/nhaarman/mockito-kotlin
+                'mockitokotlin'      : '2.2.0',             // https://github.com/nhaarman/mockito-kotlin
                 'testify'            : '1.0.0',             // https://github.com/Shopify/android-testify/releases
         ]
         coreVersions = [

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
                 'testify'            : '1.0.0',             // https://github.com/Shopify/android-testify/releases
         ]
         coreVersions = [
-                'compileSdk': 29,
+                'compileSdk': 30,
                 'minSdk'    : 19,
                 'targetSdk' : 29
         ]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.7.1-all.zip


### PR DESCRIPTION
### What does this change accomplish?

Updates most of the dependency versions

### How have you achieved it?

- Updates:
    - Compile and Target SDK from 29 to 30
    - AGP from 4.1.0 to 4.2.0-beta6
    - Gradle from 6.5 to 6.7.1
    - Kotlin from 1.3.72 to 1.4.31
    - AppCompat from 1.1.0 to 1.2.0
    - Espresso from 3.2.0 to 3.3.0
    - JUnit from 1.1.1 to 1.1.2
    - Test Rules from 1.2.0 to 1.3.0
    - Test Runner from 1.1.1 to 1.3.0

### Sample

- Updates:
    - Material from 1.1.0 to 1.3.0
    - MockitoKotlin from 2.1.0 to 2.2.0

### Tophat instructions
...

### Notice

This change must keep `master` in a shippable state; **it may be shipped without further notice**.

<!--
Need help in filling this out? See the [guide](https://github.com/Shopify/android-testify/blob/master/CONTRIBUTING.md).
-->

