### PR TITLE
Update the Sample app to use view binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Testify Change Log
 
+## Unreleased
+
+### Library
+
+#### Updates
+
+- AGP from 4.2.0-beta6 to 4.2.0-rc1
+
+### Sample
+
+#### Changes
+
+-  Remove kotlin-android-extensions from Sample and replace with viewBinding
+
+
 ## 1.1.0-beta1
 
 ### Library

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### Updates
 
-- AGP from 4.2.0-beta6 to 4.2.0-rc1
+- AGP from 4.2.0-beta6 to 4.2.0
 
 ### Sample
 

--- a/Sample/build.gradle
+++ b/Sample/build.gradle
@@ -1,6 +1,5 @@
 buildscript {
     repositories {
-        jcenter()
         google()
     }
     dependencies {
@@ -10,7 +9,6 @@ buildscript {
 
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'com.shopify.testify'
 
 android {
@@ -42,6 +40,9 @@ android {
         }
     }
 
+    buildFeatures {
+        viewBinding true
+    }
 }
 
 dependencies {

--- a/Sample/src/main/java/com/shopify/testify/sample/clients/details/ClientDetailsView.kt
+++ b/Sample/src/main/java/com/shopify/testify/sample/clients/details/ClientDetailsView.kt
@@ -27,23 +27,26 @@ import android.content.Context
 import android.util.AttributeSet
 import android.widget.LinearLayout
 import androidx.core.view.isVisible
-import kotlinx.android.synthetic.main.view_client_details.view.address as addressView
-import kotlinx.android.synthetic.main.view_client_details.view.address_row as addressRowViewGroup
-import kotlinx.android.synthetic.main.view_client_details.view.heading as headingView
-import kotlinx.android.synthetic.main.view_client_details.view.phone as phoneView
-import kotlinx.android.synthetic.main.view_client_details.view.phone_row as phoneRowViewGroup
-import kotlinx.android.synthetic.main.view_client_details.view.profile_image as profileImage
+import com.shopify.testify.sample.databinding.ViewClientDetailsBinding
 
-class ClientDetailsView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null) : LinearLayout(context, attrs) {
+class ClientDetailsView @JvmOverloads constructor(context: Context, attrs: AttributeSet? = null) :
+    LinearLayout(context, attrs) {
+
+    lateinit var binding: ViewClientDetailsBinding
+
+    override fun onFinishInflate() {
+        super.onFinishInflate()
+        binding = ViewClientDetailsBinding.bind(this)
+    }
 
     fun render(state: ClientDetailsViewState) {
-        profileImage.setImageResource(state.avatar)
-        headingView.text = state.heading
+        binding.profileImage.setImageResource(state.avatar)
+        binding.heading.text = state.heading
 
-        addressRowViewGroup.isVisible = state.address != null
-        addressView.text = state.address
+        binding.addressRow.isVisible = state.address != null
+        binding.address.text = state.address
 
-        phoneRowViewGroup.isVisible = state.phoneNumber != null
-        phoneView.text = state.phoneNumber
+        binding.phoneRow.isVisible = state.phoneNumber != null
+        binding.phone.text = state.phoneNumber
     }
 }

--- a/Sample/src/main/java/com/shopify/testify/sample/clients/index/ClientListActivity.kt
+++ b/Sample/src/main/java/com/shopify/testify/sample/clients/index/ClientListActivity.kt
@@ -29,8 +29,7 @@ import com.google.android.material.snackbar.Snackbar
 import com.shopify.testify.sample.R
 import com.shopify.testify.sample.clients.MockClientData
 import com.shopify.testify.sample.clients.details.ClientDetailsActivity.Companion.startClientDetailsActivity
-import kotlinx.android.synthetic.main.activity_client_list.fab
-import kotlinx.android.synthetic.main.activity_client_list.root_view as rootView
+import com.shopify.testify.sample.databinding.ActivityClientListBinding
 
 class ClientListActivity : AppCompatActivity(), ClientListFragment.OnListFragmentInteractionListener {
 
@@ -40,11 +39,13 @@ class ClientListActivity : AppCompatActivity(), ClientListFragment.OnListFragmen
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_client_list)
+
+        val binding = ActivityClientListBinding.inflate(layoutInflater)
+        setContentView(binding.rootView)
 
         supportActionBar?.title = getString(R.string.client_list_title)
 
-        fab.setOnClickListener { view ->
+        binding.fab.setOnClickListener { view ->
             Snackbar.make(view, "TODO: Add a client", Snackbar.LENGTH_LONG).show()
         }
     }

--- a/Sample/src/main/java/com/shopify/testify/sample/clients/index/ClientListRecyclerViewAdapter.kt
+++ b/Sample/src/main/java/com/shopify/testify/sample/clients/index/ClientListRecyclerViewAdapter.kt
@@ -23,7 +23,6 @@
  */
 package com.shopify.testify.sample.clients.index
 
-
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -34,38 +33,35 @@ import androidx.recyclerview.widget.RecyclerView
 import com.shopify.testify.sample.R
 import com.shopify.testify.sample.clients.MockClientData
 import com.shopify.testify.sample.clients.index.ClientListFragment.OnListFragmentInteractionListener
-import kotlinx.android.synthetic.main.client_list_item.view.description
-import kotlinx.android.synthetic.main.client_list_item.view.name
-import kotlinx.android.synthetic.main.client_list_item.view.profile_image
+import com.shopify.testify.sample.databinding.ClientListItemBinding
 
+class ClientListRecyclerViewAdapter(
+    private val values: List<MockClientData.Client>,
+    private val listener: OnListFragmentInteractionListener?
+) : RecyclerView.Adapter<ClientListRecyclerViewAdapter.ViewHolder>() {
 
-class ClientListRecyclerViewAdapter(private val values: List<MockClientData.Client>, private val listener: OnListFragmentInteractionListener?) : RecyclerView.Adapter<ClientListRecyclerViewAdapter.ViewHolder>() {
-
-    private val onClickListener: View.OnClickListener
-
-    init {
-        onClickListener = View.OnClickListener { v ->
-            val item = v.tag as MockClientData.Client
-            listener?.onListFragmentInteraction(item)
-        }
+    private val onClickListener: View.OnClickListener = View.OnClickListener { v ->
+        val item = v.tag as MockClientData.Client
+        listener?.onListFragmentInteraction(item)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-        val view = LayoutInflater.from(parent.context).inflate(R.layout.client_list_item, parent, false)
-        return ViewHolder(view)
+        val binding = ClientListItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return ViewHolder(binding)
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val item = values[position]
 
-        val context = holder.view.context
-        @DrawableRes val avatarDrawableId = context.resources.getIdentifier(item.avatar, "drawable", context.packageName)
+        val context = holder.itemView.context
+        @DrawableRes val avatarDrawableId =
+            context.resources.getIdentifier(item.avatar, "drawable", context.packageName)
 
         holder.nameView.text = item.name
         holder.descriptionView.text = context.getString(R.string.client_since, item.date)
         holder.avatar.setImageResource(avatarDrawableId)
 
-        with(holder.view) {
+        with(holder.itemView) {
             tag = item
             setOnClickListener(onClickListener)
         }
@@ -73,9 +69,9 @@ class ClientListRecyclerViewAdapter(private val values: List<MockClientData.Clie
 
     override fun getItemCount(): Int = values.size
 
-    inner class ViewHolder(val view: View) : RecyclerView.ViewHolder(view) {
-        val nameView: TextView = view.name
-        val descriptionView: TextView = view.description
-        val avatar: ImageView = view.profile_image
+    inner class ViewHolder(binding: ClientListItemBinding) : RecyclerView.ViewHolder(binding.root) {
+        val nameView: TextView = binding.name
+        val descriptionView: TextView = binding.description
+        val avatar: ImageView = binding.profileImage
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 
     ext {
         versions = [
-                'androidGradlePlugin': '4.2.0-beta06',      // https://developer.android.com/studio/releases/gradle-plugin.html
+                'androidGradlePlugin': '4.2.0-rc01',      // https://developer.android.com/studio/releases/gradle-plugin.html
                 'androidx'           : [
                         'constraintLayout': '2.0.0-beta4',  // https://developer.android.com/jetpack/androidx/releases
                         'appCompat'       : '1.2.0',        // https://developer.android.com/jetpack/androidx/releases

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 
     ext {
         versions = [
-                'androidGradlePlugin': '4.2.0-rc01',      // https://developer.android.com/studio/releases/gradle-plugin.html
+                'androidGradlePlugin': '4.2.0',      // https://developer.android.com/studio/releases/gradle-plugin.html
                 'androidx'           : [
                         'constraintLayout': '2.0.0-beta4',  // https://developer.android.com/jetpack/androidx/releases
                         'appCompat'       : '1.2.0',        // https://developer.android.com/jetpack/androidx/releases


### PR DESCRIPTION
### What does this change accomplish?

- AGP from 4.2.0-beta6 to 4.2.0-rc1
- Remove kotlin-android-extensions from Sample and replace with viewBinding

### Tophat instructions

Sample should continue to build and run properly
All tests in the Sample should pass

### Notice

This change must keep `master` in a shippable state; **it may be shipped without further notice**.

<!--
Need help in filling this out? See the [guide](https://github.com/Shopify/android-testify/blob/master/CONTRIBUTING.md).
-->
