### PR TITLE
Declare support for Android Studio Arctic Fox

### DIFF
--- a/Plugins/IntelliJ/CHANGELOG.md
+++ b/Plugins/IntelliJ/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [0.1.1]
+
+### Updated
+
+- Intellij plugin now supports Android Studio Arctic Fox | 2020.3.1 Beta 2
+  Build 203.*
+
 ## [0.1.0]
 
 ### Added

--- a/Plugins/IntelliJ/build.gradle.kts
+++ b/Plugins/IntelliJ/build.gradle.kts
@@ -47,7 +47,7 @@ intellij {
     downloadSources = platformDownloadSources.toBoolean()
     updateSinceUntilBuild = true
 
-    alternativeIdePath = "/Applications/Android Studio 4.2 Preview.app"
+    alternativeIdePath = "/Applications/Android Studio Preview.app"
 
 //  Plugin Dependencies:
 //  https://www.jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_dependencies.html

--- a/Plugins/IntelliJ/gradle.properties
+++ b/Plugins/IntelliJ/gradle.properties
@@ -3,9 +3,9 @@
 
 pluginGroup = com.shopify.testify
 pluginName = Android Testify - Screenshot Instrumentation Tests
-pluginVersion = 0.1.0
+pluginVersion = 0.1.1
 pluginSinceBuild = 193
-pluginUntilBuild = 202.*
+pluginUntilBuild = 203.*
 
 platformType = IC
 platformVersion = 2020.1


### PR DESCRIPTION
### What does this change accomplish?

Intellij plugin now supports Android Studio Arctic Fox | 2020.3.1 Beta 2 | Build 203.*

### How have you achieved it?

Bumped supported version to 203.*

### Tophat instructions

1. Download and install Android Studio Arctic Fox (https://developer.android.com/studio/preview)
1. `cd ./Plugins/IntelliJ/`
1. `./gradlew buildPlugin runIde`

Verify that the Testify plugin is working correctly in Arctic Fox

### Notice

This change must keep `master` in a shippable state; **it may be shipped without further notice**.

<!--
Need help in filling this out? See the [guide](https://github.com/Shopify/android-testify/blob/master/CONTRIBUTING.md).
-->
