### PR TITLE
Replace deprecated maven plugin with maven-publish

### DIFF
--- a/.github/workflows/central_release.yml
+++ b/.github/workflows/central_release.yml
@@ -15,7 +15,7 @@ jobs:
           java-version: '8'
           distribution: 'adopt'
       - name: Publish Testify Library
-        run: ./gradlew Library:uploadArchives
+        run: ./gradlew Library:publish
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -23,7 +23,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
       - name: Publish Testify Gradle plugin
-        run: ./gradlew Plugin:uploadArchives
+        run: ./gradlew Plugin:publish
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/Library/build.gradle
+++ b/Library/build.gradle
@@ -1,8 +1,6 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'maven'
-    id 'signing'
     id 'org.jetbrains.dokka'
 }
 
@@ -20,9 +18,8 @@ ext {
     ]
 }
 
-def VERSION_NAME = "$project.versions.testify"
-
-version = VERSION_NAME
+version = "$project.versions.testify"
+group = pom.publishedGroupId
 archivesBaseName = pom.artifact
 
 android {
@@ -40,7 +37,7 @@ android {
         minSdkVersion coreVersions.minSdk
         targetSdkVersion coreVersions.targetSdk
         versionCode 1
-        versionName VERSION_NAME
+        versionName version
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         kotlinOptions {
@@ -96,7 +93,7 @@ task sourcesJar(type: Jar) {
     classifier = 'sources'
 }
 
-afterEvaluate { project ->
+afterEvaluate {
     apply from: "../publish.build.gradle"
 }
 

--- a/Plugins/Gradle/build.gradle
+++ b/Plugins/Gradle/build.gradle
@@ -11,8 +11,6 @@ plugins {
     id 'groovy'
     id 'kotlin'
     id 'org.jetbrains.dokka'
-    id 'maven'
-    id 'signing'
 }
 
 ext {
@@ -29,7 +27,11 @@ ext {
     ]
 }
 
-def VERSION_NAME = "$project.versions.testify"
+version = "$project.versions.testify"
+group = pom.publishedGroupId
+archivesBaseName = pom.artifact
+
+
 sourceCompatibility = 1.8
 
 test {
@@ -62,15 +64,11 @@ compileTestKotlin {
     }
 }
 
-group = pom.publishedGroupId
-archivesBaseName = pom.artifact
-version = VERSION_NAME
-
 jar {
     manifest {
         attributes "Implementation-Title": "Testify"
         attributes "Implementation-Vendor": "Shopify"
-        attributes "Implementation-Version": version
+        attributes "Implementation-Version": archiveVersion
     }
 }
 

--- a/Plugins/IntelliJ/build.gradle.kts
+++ b/Plugins/IntelliJ/build.gradle.kts
@@ -30,7 +30,6 @@ version = pluginVersion
 // Configure project's dependencies
 repositories {
     mavenCentral()
-    jcenter()
 }
 dependencies {
     implementation(kotlin("stdlib-jdk8"))

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 buildscript {
     repositories {
+        mavenLocal()
         google()
         mavenCentral()
-        mavenLocal()
     }
 
     ext {
@@ -49,7 +49,6 @@ allprojects {
         mavenLocal()
         google()
         mavenCentral()
-        jcenter()
     }
 }
 

--- a/ktlint.gradle
+++ b/ktlint.gradle
@@ -1,5 +1,5 @@
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 configurations {

--- a/publish.build.gradle
+++ b/publish.build.gradle
@@ -1,4 +1,5 @@
-group = pom.publishedGroupId
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
 
 dokka {
     outputFormat = "html"
@@ -11,67 +12,76 @@ dokka {
 }
 
 task javadocJar(type: Jar, dependsOn: dokka) {
-    classifier = 'javadoc'
-    baseName = 'testify'
+    archiveClassifier.set('javadoc')
+    archiveBaseName.set('testify')
     from dokka.outputDirectory
 }
 
-artifacts {
-    archives javadocJar
-    archives sourcesJar
-}
-
-signing {
-    required { gradle.taskGraph.hasTask("uploadArchives") }
-    def signingKeyId = findProperty("signingKeyId")
-    def signingKey = findProperty("signingKey")
-    def signingPassword = findProperty("signingPassword")
-    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
-    sign configurations.archives
-}
-
-uploadArchives {
+publishing {
     repositories {
-        mavenDeployer {
-            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+        maven {
+            def release =  "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+            def snapshot = "https://oss.sonatype.org/content/repositories/snapshots/"
+            url = version.endsWith('SNAPSHOT') ? snapshot : release
 
-            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-                authentication(userName: System.getenv("OSSRH_USERNAME"), password: System.getenv("OSSRH_PASSWORD"))
+            credentials {
+                username System.getenv("OSSRH_USERNAME")
+                password System.getenv("OSSRH_PASSWORD")
+            }
+        }
+    }
+
+    publications {
+        maven(MavenPublication) {
+            if (project.hasProperty('android')) {
+                from components.release
+            } else {
+                from components.java
             }
 
-            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-                authentication(userName: System.getenv("OSSRH_USERNAME"), password: System.getenv("OSSRH_PASSWORD"))
+            afterEvaluate {
+                groupId = project.ext.pom.publishedGroupId
+                artifactId = project.ext.pom.artifact
+                version = project.version
             }
+
+            artifact javadocJar
+            artifact sourcesJar
 
             pom {
-                project {
-                    groupId project.ext.pom.publishedGroupId
-                    artifactId project.ext.pom.artifact
+                name = project.ext.pom.libraryName
+                description = project.ext.pom.libraryDescription
+                url = project.ext.pom.siteUrl
 
-                    name project.ext.pom.libraryName
-                    description project.ext.pom.libraryDescription
-                    url project.ext.pom.siteUrl
-
-                    developers {
-                        developer {
-                            name project.ext.pom.author
-                        }
+                licenses {
+                    license {
+                        name = project.ext.pom.licenseName
+                        url = project.ext.pom.licenseUrl
                     }
-
-                    licenses {
-                        license {
-                            name project.ext.pom.licenseName
-                            url project.ext.pom.licenseUrl
-                        }
+                }
+                developers {
+                    developer {
+                        name = project.ext.pom.author
                     }
-
-                    scm {
-                        connection = project.ext.pom.gitUrl
-                        developerConnection = project.ext.pom.gitUrl
-                        url = project.ext.pom.siteUrl
-                    }
+                }
+                scm {
+                    connection = project.ext.pom.gitUrl
+                    developerConnection = project.ext.pom.gitUrl
+                    url = project.ext.pom.siteUrl
                 }
             }
         }
     }
 }
+
+signing {
+    def signingKeyId = findProperty("signingKeyId")
+    def signingKey = findProperty("signingKey")
+    def signingPassword = findProperty("signingPassword")
+
+    required { signingKeyId && signingKey && signingPassword }
+
+    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+    sign publishing.publications.maven
+}
+


### PR DESCRIPTION
### What does this change accomplish?
Part of supporting Gradle 7.0.

Removes the deprecated `maven` plugin, replacing it with `maven-publish` to handle our Maven publishing tasks.

Added ability to run `publishToMavenLocal` and skip signing if you don't have the environment variables set.

### Tophat instructions
1. Publish `Plugin` and `Library` to your local maven repository
    `./gradlew Library:publishToMavenLocal Plugin:publishToMavenLocal`
2. Validate that the packages being generated contain expected POM information and artifacts 
    Local `Plugin`: `~/.m2/repository/com/shopify/testify/plugin/1.1.0-beta2`
    Published `Plugin`: https://repo1.maven.org/maven2/com/shopify/testify/plugin/1.1.0-beta2/

    Local `Library`: `~/.m2/repository/com/shopify/testify/testify/1.1.0-beta2`
    Published `Library`: https://repo1.maven.org/maven2/com/shopify/testify/testify/1.1.0-beta2/
