### PR TITLE
Migrate to Dokka 1.4.32 for Gradle 7 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
                         ]
                 ],
                 'colormath'          : '1.4.1',             // https://github.com/ajalt/colormath/releases
-                'dokka'              : '0.10.0',            // https://github.com/Kotlin/dokka/releases
+                'dokka'              : '1.4.32',            // https://github.com/Kotlin/dokka/releases
                 'kotlin'             : '1.4.31',            // https://kotlinlang.org/
                 'ktlint'             : '0.36.0',            // https://github.com/pinterest/ktlint
                 'material'           : '1.3.0',             // https://material.io/develop/android/docs/getting-started/

--- a/publish.build.gradle
+++ b/publish.build.gradle
@@ -1,20 +1,20 @@
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
-dokka {
-    outputFormat = "html"
-    outputDirectory = "$buildDir/javadoc"
-
-    configuration {
-        includeNonPublic = false
-        reportUndocumented = false
+dokkaJavadoc {
+    dokkaSourceSets {
+        configureEach {
+            includeNonPublic.set(false)
+            reportUndocumented.set(false)
+            noAndroidSdkLink.set(false)
+        }
     }
 }
 
-task javadocJar(type: Jar, dependsOn: dokka) {
+task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {
     archiveClassifier.set('javadoc')
     archiveBaseName.set('testify')
-    from dokka.outputDirectory
+    from dokkaJavadoc.outputDirectory
 }
 
 publishing {


### PR DESCRIPTION
### What does this change accomplish?
Part of supporting Gradle 7.0

Upgrade Dokka to 1.4.32 which resolves some deprecated functionality used in old version.



### How have you achieved it?
Following _doks_ at https://github.com/Kotlin/dokka/blob/master/runners/gradle-plugin/MIGRATION.md.

### Tophat instructions
1. Can publish to local repository and check if documentation works as expected
