### PR TITLE
Rename rootViewId setter for Java interoperability

### DIFF
--- a/Library/src/main/java/com/shopify/testify/ScreenshotRule.kt
+++ b/Library/src/main/java/com/shopify/testify/ScreenshotRule.kt
@@ -100,11 +100,14 @@ typealias ExclusionRectProvider = (rootView: ViewGroup, exclusionRects: MutableS
 @Suppress("unused", "MemberVisibilityCanBePrivate")
 open class ScreenshotRule<T : Activity> @JvmOverloads constructor(
     protected val activityClass: Class<T>,
-    @IdRes protected var rootViewId: Int = android.R.id.content,
+    @IdRes rootViewId: Int = android.R.id.content,
     initialTouchMode: Boolean = false,
     protected val launchActivity: Boolean = true,
     enableReporter: Boolean = false
 ) : ActivityTestRule<T>(activityClass, initialTouchMode, launchActivity), TestRule {
+
+    @IdRes protected var rootViewId = rootViewId
+        @JvmName("rootViewIdResource") set
 
     @LayoutRes
     private var targetLayoutId: Int = NO_ID


### PR DESCRIPTION
### What does this change accomplish?

When `rootViewId` was made protected it inadvertently broke interop with Java subclasses due to the conflicting method signatures of the generated setter and this function https://github.com/Shopify/android-testify/blob/1ad32a9f5777f07768773c536a36ed76fdbdfb64/Library/src/main/java/com/shopify/testify/ScreenshotRule.kt#L218

This fix renames the setter for Java classes while Kotlin property accessors remain unchanged.

### How have you achieved it?
1. Use `JvmName` annotation and rename the Java setter `setRootViewIdResource`

### Tophat instructions
1. Create a class that extends `ScreenshotRule` in Java and it will fail to compile due to conflicting method signatures. 
