### PR TITLE
Fix Issue #228: Fix IndexOutOfBoundsException when processing uneven image buffer chunks

### DIFF
--- a/.github/workflows/library_build.yml
+++ b/.github/workflows/library_build.yml
@@ -67,3 +67,10 @@ jobs:
       # Run test Gradle task
       - name: Run JVM Tests
         run: ./gradlew :Library:test
+
+      - name: Archive test results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: junit-test-results
+          path: ./Library/build/reports/tests/**/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 #### Bug fixes
 
+- https://github.com/Shopify/android-testify/issues/228, https://github.com/Shopify/android-testify/issues/215
+    Account for uneven processing chunk sizes. As Testify processes, it divides the images into chunks for faster, parallel processing.
+    A bug in the original code assumed that each processing chunk would be equally sized. This caused an out-of-bounds exception in any case where the number of pixels in the image could not be evenly divided.
+
 - https://github.com/Shopify/android-testify/issues/216
     You can now use `ScreenshotRule.setExactness()` in conjunction with `ScreenshotRule.defineExclusionRects()`. You can now define both an exclusion area and an exactness threshold.
 

--- a/Library/build.gradle
+++ b/Library/build.gradle
@@ -66,7 +66,7 @@ android {
         implementation "androidx.test:runner:${versions.androidx.test.runner}"
         implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:${versions.kotlin}"
         implementation "com.github.ajalt:colormath:${versions.colormath}"
-        implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.3") {
+        implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:${versions.kotlinx}") {
             exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-jdk8'
             exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib-jdk7'
             exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib'
@@ -75,6 +75,7 @@ android {
 
         testImplementation "org.mockito:mockito-core:${versions.mockito2}"
         testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:${versions.mockitokotlin}"
+        testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:${versions.kotlinx}"
 
         androidTestImplementation "androidx.test.ext:junit:${versions.androidx.test.junit}"
         androidTestImplementation "androidx.test:runner:${versions.androidx.test.runner}"

--- a/Library/src/main/java/com/shopify/testify/internal/processor/BitmapExtentions.kt
+++ b/Library/src/main/java/com/shopify/testify/internal/processor/BitmapExtentions.kt
@@ -1,6 +1,8 @@
 package com.shopify.testify.internal.processor
 
 import android.graphics.Bitmap
+import androidx.annotation.VisibleForTesting
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.asCoroutineDispatcher
 import java.util.concurrent.Executors
 
@@ -13,7 +15,17 @@ fun ParallelPixelProcessor.TransformResult.createBitmap(): Bitmap {
     )
 }
 
-var numberOfCores = Runtime.getRuntime().availableProcessors()
+private val numberOfAvailableCores = Runtime.getRuntime().availableProcessors()
+
+@VisibleForTesting
+var maxNumberOfChunkThreads = numberOfAvailableCores
+
+@VisibleForTesting
+var _executorDispatcher: CoroutineDispatcher? = null
+
 val executorDispatcher by lazy {
-    Executors.newFixedThreadPool(numberOfCores).asCoroutineDispatcher()
+    if (_executorDispatcher == null) {
+        _executorDispatcher = Executors.newFixedThreadPool(numberOfAvailableCores).asCoroutineDispatcher()
+    }
+    _executorDispatcher!!
 }

--- a/Library/src/test/java/com/shopify/testify/ParallelPixelProcessorTest.kt
+++ b/Library/src/test/java/com/shopify/testify/ParallelPixelProcessorTest.kt
@@ -1,63 +1,138 @@
 package com.shopify.testify
 
 import android.graphics.Bitmap
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import com.shopify.testify.internal.processor.ParallelPixelProcessor
-import com.shopify.testify.internal.processor.numberOfCores
+import com.shopify.testify.internal.processor._executorDispatcher
+import com.shopify.testify.internal.processor.maxNumberOfChunkThreads
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.ObsoleteCoroutinesApi
+import kotlinx.coroutines.newSingleThreadContext
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
 
+@ObsoleteCoroutinesApi
+@ExperimentalCoroutinesApi
 class ParallelPixelProcessorTest {
+
+    private val mainThreadSurrogate = newSingleThreadContext("UI thread")
 
     companion object {
         const val WIDTH = 1080
         const val HEIGHT = 2220
     }
 
-    private fun mockBitmap(): Bitmap {
+    private fun mockBitmap(width: Int = WIDTH, height: Int = HEIGHT): Bitmap {
         return mock<Bitmap>().apply {
-            doReturn(WIDTH).whenever(this).height
-            doReturn(HEIGHT).whenever(this).width
+            doReturn(width).whenever(this).height
+            doReturn(height).whenever(this).width
+            doReturn(0xffffffff.toInt()).whenever(this).getPixel(any(), any())
         }
     }
 
-    private val expectedX = (0 until WIDTH).flatMap { (0 until HEIGHT).toList() }
-    private val expectedY = (0 until WIDTH).flatMap { y -> (0 until HEIGHT).map { y } }
     private lateinit var pixelProcessor: ParallelPixelProcessor
+
+    private fun forceSingleThreadedExecution() {
+        Dispatchers.setMain(mainThreadSurrogate)
+        _executorDispatcher = Dispatchers.Main
+    }
 
     @Before
     fun setUp() {
+        forceSingleThreadedExecution()
         pixelProcessor = ParallelPixelProcessor
             .create()
             .baseline(mockBitmap())
             .current(mockBitmap())
     }
 
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        mainThreadSurrogate.close()
+    }
+
     @Test
     fun default() {
-        numberOfCores = 1
+        maxNumberOfChunkThreads = 1
 
-        var index = 0
-        pixelProcessor.analyze { _, _, (x, y) ->
-            assertEquals(expectedX[index], x)
-            assertEquals(expectedY[index], y)
-            index++
+        val index = AtomicInteger(0)
+        pixelProcessor.analyze { _, _, _ ->
+            index.incrementAndGet()
             true
         }
+        assertEquals(WIDTH * HEIGHT, index.get())
+    }
+
+    @Test
+    fun twoCores() {
+        maxNumberOfChunkThreads = 2
+
+        val index = AtomicInteger(0)
+        pixelProcessor.analyze { _, _, _ ->
+            index.incrementAndGet()
+            true
+        }
+
+        assertEquals(WIDTH * HEIGHT, index.get())
+    }
+
+    @Test
+    fun oddNumberOfCores() {
+        maxNumberOfChunkThreads = 7
+
+        val index = AtomicInteger(0)
+        pixelProcessor.analyze { _, _, _ ->
+            index.incrementAndGet()
+            true
+        }
+
+        assertEquals(WIDTH * HEIGHT, index.get())
+    }
+
+    @Test
+    fun oddNumberOfPixels() {
+        maxNumberOfChunkThreads = 2
+
+        pixelProcessor = ParallelPixelProcessor
+            .create()
+            .baseline(mockBitmap(3, 3))
+            .current(mockBitmap(3, 3))
+
+        val expected = mutableSetOf(
+            0 to 0, 1 to 0, 2 to 0,
+            0 to 1, 1 to 1, 2 to 1,
+            0 to 2, 1 to 2, 2 to 2
+        )
+
+        val index = AtomicInteger(0)
+        pixelProcessor.analyze { _, _, (x, y) ->
+            assertTrue(expected.remove(x to y))
+            index.incrementAndGet()
+            true
+        }
+        assertEquals(9, index.get())
+        assertTrue(expected.isEmpty())
     }
 
     private fun assertPosition(index: Int, position: Pair<Int, Int>) {
-        val width = 1080
-        val (x, y) = pixelProcessor.getPosition(index, width)
+        val (x, y) = pixelProcessor.getPosition(index, WIDTH)
         assertEquals(position, x to y)
     }
 
     @Test
     fun multicoreChunks() {
-        numberOfCores = 2
+        maxNumberOfChunkThreads = 2
         assertPosition(7, 7 to 0)
         assertPosition(500, 500 to 0)
         assertPosition(1500, 420 to 1)

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ buildscript {
                 'colormath'          : '1.4.1',             // https://github.com/ajalt/colormath/releases
                 'dokka'              : '1.4.32',            // https://github.com/Kotlin/dokka/releases
                 'kotlin'             : '1.4.31',            // https://kotlinlang.org/
+                'kotlinx'            : '1.4.3',             // https://github.com/Kotlin/kotlinx.coroutines/releases
                 'ktlint'             : '0.36.0',            // https://github.com/pinterest/ktlint
                 'material'           : '1.3.0',             // https://material.io/develop/android/docs/getting-started/
                 'mockito2'           : '3.3.3',             // https://github.com/mockito/mockito/releases


### PR DESCRIPTION
### What does this change accomplish?

Resolves #228
Resolves #215

### How have you achieved it?

While adding additional unit tests, I uncovered additional ways to trigger an `IndexOutOfBoundsException` error.

The solution is to account for uneven processing chunk sizes. 

As Testify processes, it divides the images into chunks for faster, parallel processing. A bug in the original code assumed that each processing chunk would be equally sized. This caused an out-of-bounds exception in any case where the number of pixels in the image could not be evenly divided.

In most cases, Testify will be used to capture a bitmap that is something like 1080x1920 (2,073,600 pixels) and will run on a 2 or 4-core CPU. In either case, this is evenly divisible and means that each processor core will be able to process an equal number of pixels.

However, in the case where the bitmap is not evenly divisible by the number of CPU cores, the remainder will be processed separately. For example, if you have a 3x3 bitmap (9 total pixels) running on a 2-core device, Testify will divide the image buffer into three parts: two 4-pixel chunks and one 1-pixel chunk. The bug in Testify was that it was assumed that each chunk was of equal size, and so an index-out-of-bounds error would occur when trying to process non-existent pixels in the final image buffer chunk.

The solution is to accurately use the correct size for each chunk via the new method, `getSizeOfChunk()`. The rest of this PR is additional testing and testing improvements.

### Tophat instructions

It can be difficult to reproduce this error on a normal device setup. 

The most straightforward way to reproduce this seems to be to create an emulator based off the recommended Testify settings found [here](https://github.com/Shopify/android-testify/blob/master/RECIPES.md#setting-up-an-emulator-to-run-the-sample) but then edit the `Advanced Settings` and set the `Multi-Core CPU` setting to `7`. This generates an emulator with unequally divisible pixel buffer sizes.

Once configured, run the tests found in the `Sample` application. You should find that the `exclusions` and `generatedDiffs` tests will fail on `master` and pass on this branch.
