### PR TITLE
Fix blocking tests on GitHub Action CI

### DIFF
--- a/.github/workflows/library_build.yml
+++ b/.github/workflows/library_build.yml
@@ -20,6 +20,7 @@ jobs:
   instrumentationTests:
     name: Instrumentation Tests
     runs-on: macos-latest
+    timeout-minutes: 30
     steps:
 
     - name: Fetch Sources
@@ -40,6 +41,7 @@ jobs:
     name: Test Library
     needs: gradleValidation
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
 
       # Check out current repository

--- a/Library/src/test/java/com/shopify/testify/RegionCompareTest.kt
+++ b/Library/src/test/java/com/shopify/testify/RegionCompareTest.kt
@@ -31,13 +31,38 @@ import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
+import com.shopify.testify.internal.processor._executorDispatcher
 import com.shopify.testify.internal.processor.compare.FuzzyCompare
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.ObsoleteCoroutinesApi
+import kotlinx.coroutines.newSingleThreadContext
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import java.nio.IntBuffer
 
+@ObsoleteCoroutinesApi
+@ExperimentalCoroutinesApi
 class RegionCompareTest {
+
+    private val mainThreadSurrogate = newSingleThreadContext("UI thread")
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(mainThreadSurrogate)
+        _executorDispatcher = Dispatchers.Main
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        mainThreadSurrogate.close()
+    }
 
     private val rectSet = HashSet<Rect>()
     private val regionCompare = FuzzyCompare(null, rectSet)


### PR DESCRIPTION
I noticed that the checks running the JVM tests were timing out. I'm not entirely sure why this wasn't always failing because the RegionCompareTests were using multithreaded tests without declaring a single-threaded test coroutine dispatcher.

This PR does two things:

1. Sets a timeout on the GitHub actions
2. Sets up a single threaded context for the RegionCompareTest