### PR TITLE
Upgrade core dependency versions

### DIFF
--- a/.github/workflows/library_build.yml
+++ b/.github/workflows/library_build.yml
@@ -13,6 +13,12 @@ jobs:
       - name: Fetch Sources
         uses: actions/checkout@v2
 
+      # Setup Java 11 environment for the next steps
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
       # Validate wrapper
       - name: Gradle Wrapper Validation
         uses: gradle/wrapper-validation-action@v1
@@ -25,6 +31,12 @@ jobs:
 
     - name: Fetch Sources
       uses: actions/checkout@v2
+
+      # Setup Java 11 environment for the next steps
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
 
     - name: Validate Build
       run: ./gradlew :Library:assemble
@@ -48,11 +60,11 @@ jobs:
       - name: Fetch Sources
         uses: actions/checkout@v2
 
-      # Setup Java 1.8 environment for the next steps
+      # Setup Java 11 environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       # Cache Gradle dependencies
       - name: Setup Cache

--- a/.github/workflows/plugin_build.yml
+++ b/.github/workflows/plugin_build.yml
@@ -27,11 +27,11 @@ jobs:
       - name: Fetch Sources
         uses: actions/checkout@v2
 
-      # Setup Java 1.8 environment for the next steps
+      # Setup Java 11 environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
 
       # Cache Gradle dependencies
       - name: Setup Cache

--- a/.github/workflows/sample_build.yml
+++ b/.github/workflows/sample_build.yml
@@ -11,6 +11,12 @@ jobs:
     - name: Fetch Sources
       uses: actions/checkout@v2
 
+    # Setup Java 11 environment for the next steps
+    - name: Setup Java
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+
     - name: Validate build
       run: ./gradlew Sample:assemble
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 #### Updates
 
+- Compile SDK from 30 to 31
+- Target SDK from 30 to 31
+- Gradle Wrapper from 6.7.1 to 7.0.2
+- Android Gradle Plugin from 4.2.0 to 7.0.3
 - kotlin upgraded from 1.4.31 to 1.5.31
 - androidx.appcompat:appcompat from 1.2.0 to 1.3.1
 - androidx.test.espresso from 3.3.0 to 3.4.0

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 
     ext {
         versions = [
-                'androidGradlePlugin': '4.2.0',             // https://developer.android.com/studio/releases/gradle-plugin.html
+                'androidGradlePlugin': '7.0.3',             // https://developer.android.com/studio/releases/gradle-plugin.html
                 'androidx'           : [
                         'constraintLayout': '2.0.0-beta4',  // https://developer.android.com/jetpack/androidx/releases
                         'activityCompose' : '1.4.0',        // https://developer.android.com/jetpack/androidx/versions
@@ -15,7 +15,6 @@ buildscript {
                         'coreKtx'         : '1.1.0',        // https://developer.android.com/jetpack/androidx/releases
                         'lifecycleKtx'    : '2.4.0',        // https://developer.android.com/jetpack/androidx/releases
                         'test'            : [
-                                'core'    : '2.1.0',        // https://developer.android.com/jetpack/androidx/releases
                                 'coreKtx' : '1.4.0',        // https://mvnrepository.com/artifact/androidx.test/core-ktx
                                 'espresso': '3.4.0',        // https://developer.android.com/jetpack/androidx/releases
                                 'junit'   : '1.1.3',        // https://developer.android.com/jetpack/androidx/releases
@@ -36,9 +35,9 @@ buildscript {
                 'testify'            : '1.2.0-alpha01',     // https://github.com/Shopify/android-testify/releases
         ]
         coreVersions = [
-                'compileSdk': 30,
+                'compileSdk': 31,
                 'minSdk'    : 19,
-                'targetSdk' : 30
+                'targetSdk' : 31
         ]
     }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip


### PR DESCRIPTION
### What does this change accomplish?

- Compile SDK from 30 to 31
- Target SDK from 30 to 31
- Gradle Wrapper from 6.7.1 to 7.0.2
- Android Gradle Plugin from 4.2.0 to 7.0.3

