### PR TITLE
Issue-250: Support for Android Studio Chipmunk (2021.2.1)

### DIFF
--- a/Plugins/IntelliJ/CHANGELOG.md
+++ b/Plugins/IntelliJ/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [0.1.3]
+
+### Updated
+
+- Intellij plugin now supports Android Studio Chipmunk | 2021.2.1
+  Build 212.*
+
 ## [0.1.2]
 
 ### Updated

--- a/Plugins/IntelliJ/gradle.properties
+++ b/Plugins/IntelliJ/gradle.properties
@@ -5,7 +5,7 @@ pluginGroup = com.shopify.testify
 pluginName = Android Testify - Screenshot Instrumentation Tests
 pluginVersion = 0.1.2
 pluginSinceBuild = 193
-pluginUntilBuild = 211.*
+pluginUntilBuild = 212.*
 
 platformType = IC
 platformVersion = 2020.1

--- a/Plugins/IntelliJ/gradle.properties
+++ b/Plugins/IntelliJ/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = com.shopify.testify
 pluginName = Android Testify - Screenshot Instrumentation Tests
-pluginVersion = 0.1.2
+pluginVersion = 0.1.3
 pluginSinceBuild = 193
 pluginUntilBuild = 212.*
 

--- a/Plugins/IntelliJ/src/main/kotlin/com/shopify/testify/PsiExtensions.kt
+++ b/Plugins/IntelliJ/src/main/kotlin/com/shopify/testify/PsiExtensions.kt
@@ -37,7 +37,7 @@ val AnActionEvent.moduleName: String
         val ktFile = (psiFile as? KtFile)
         val projectName = ktFile?.project?.name?.replace(' ', '_') ?: ""
         val moduleName = ktFile?.module?.name ?: ""
-        return moduleName.removePrefix("$projectName.")
+        return moduleName.removeSuffix(".androidTest").removePrefix("$projectName.")
     }
 
 val PsiElement.baselineImageName: String


### PR DESCRIPTION
### What does this change accomplish?

Resolves https://github.com/Shopify/android-testify/issues/250

### How have you achieved it?

The bug was that the `ktFile` module name now includes the test variant (`androidTest`) as a suffix. This needs to be trimmed to match the expected Gradle project name.

### Tophat instructions

1. Download Chipmunk from https://developer.android.com/studio/
2. Install the pre-built plugin from [Testify IntelliJ Plugin-0.1.3.jar.zip](https://github.com/Shopify/android-testify/files/8655039/Testify.IntelliJ.Plugin-0.1.3.jar.zip)
3. Open the `Sample` source code in the preview build of Android Studio
4. Verify that the 📷 icon is present in the screenshot test files and that the various commands work as expected.